### PR TITLE
Add Versioned User-Agent Header

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -10,7 +10,10 @@ function JsonClient(baseUrl, mainOptions) {
 		baseUrl += '/';
 
 	mainOptions = objectMerge({
-		headers: { Accept: 'application/json' },
+		headers: {
+			Accept:       'application/json',
+			'User-Agent': 'json-client/0.8.4 (+https://github.com/billinghamj/json-client)',
+		},
 	}, mainOptions || {});
 
 	return function JsonClientRequest(method, path, params, body, options) {


### PR DESCRIPTION
Currently no `User-Agent` header is set with the default options, define one identifying json-client and its version.